### PR TITLE
feat/Activate refund + pass filter-hook to order-management-plugin

### DIFF
--- a/changelog.readme
+++ b/changelog.readme
@@ -1,3 +1,6 @@
+## 1.2.2
+* Feature: Listen for refund and pass to order management
+
 ## 1.2.1
 * Fix: prevent multiple notes
 

--- a/changelog.readme
+++ b/changelog.readme
@@ -1,5 +1,5 @@
-## 1.2.2
-* Feature: Listen for refund and pass to order management
+## 1.3.0
+* Feature: Active Refund using Ledyer and listen for refund and pass to order management
 
 ## 1.2.1
 * Fix: prevent multiple notes

--- a/classes/class-ledyer-lco-gateway.php
+++ b/classes/class-ledyer-lco-gateway.php
@@ -337,6 +337,20 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		}
 
 		/**
+		 * This plugin doesn't handle order management, but it allows Ledyer Order Management plugin to process refunds
+		 * and then return true or false.
+		 *
+		 * @param int      $order_id WooCommerce order ID.
+		 * @param null|int $amount Refund amount.
+		 * @param string   $reason Reason for refund.
+		 *
+		 * @return bool
+		 */
+		public function process_refund( $order_id, $amount = null, $reason = '' ) {
+			return apply_filters( 'wc_ledyer_checkout_process_refund', false, $order_id, $amount, $reason );
+		}
+
+		/**
 		 * Displays Ledyer Checkout thank you iframe and clears Ledyer order ID value from WC session.
 		 *
 		 * @param int $order_id WooCommerce order ID.

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -51,7 +51,7 @@ class Ledyer_Checkout_For_WooCommerce {
 	 */
 	public $checkout;
 
-	const VERSION = '1.2.2';
+	const VERSION = '1.3.0';
 	const SLUG = 'ledyer-checkout-for-woocommerce';
 	const SETTINGS = 'ledyer_checkout_for_woocommerce_settings';
 

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -51,7 +51,7 @@ class Ledyer_Checkout_For_WooCommerce {
 	 */
 	public $checkout;
 
-	const VERSION = '1.2.1';
+	const VERSION = '1.2.2';
 	const SLUG = 'ledyer-checkout-for-woocommerce';
 	const SETTINGS = 'ledyer_checkout_for_woocommerce_settings';
 

--- a/ledyer-checkout-for-woocommerce.php
+++ b/ledyer-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Ledyer Checkout payment gateway for WooCommerce.
  * Author: Maksimer/Ledyer
  * Author URI: https://www.maksimer.com/
- * Version: 1.2.2
+ * Version: 1.3.0
  * Text Domain: ledyer-checkout-for-woocommerce
  * Domain Path: /languages
  *

--- a/ledyer-checkout-for-woocommerce.php
+++ b/ledyer-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Ledyer Checkout payment gateway for WooCommerce.
  * Author: Maksimer/Ledyer
  * Author URI: https://www.maksimer.com/
- * Version: 1.2.1
+ * Version: 1.2.2
  * Text Domain: ledyer-checkout-for-woocommerce
  * Domain Path: /languages
  *

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 8.1.11
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 8.1.11
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3
-Stable tag: 1.2.2
+Stable tag: 1.3.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Refund functionality must be activated by the payment-gateway plugin.
SInce we want to handle refunds in the order-management-plugin we only activate the functionality, implement the process_refund hook and then pass on a add_filter-hook that the order-management-plugin will catch.

