### PR TITLE
feat(LED-96): order recipient in order overview

### DIFF
--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -29,6 +29,8 @@ jQuery(function ($) {
         ledyerUpdateNeeded: false,
         shippingEmailExists: false,
         shippingPhoneExists: false,
+        shippingFirstNameExists: false,
+        shippingLastNameExists: false,
 
         /**
          * Triggers on document ready.
@@ -164,6 +166,12 @@ jQuery(function ($) {
                         if (name === 'shipping_email') {
                             lco_wc.shippingEmailExists = true;
                         }
+                        if (name === 'shipping_first_name') {
+                            lco_wc.shippingFirstNameExists = true;
+                        }
+                        if (name === 'shipping_last_name') {
+                            lco_wc.shippingLastNameExists = true;
+                        }
                         $('p#' + name + '_field').appendTo('#lco-extra-checkout-fields');
                     } else {
                         $('input[name="' + name + '"]').closest('p').appendTo('#lco-extra-checkout-fields');
@@ -272,12 +280,18 @@ jQuery(function ($) {
                 'shipping_country' in data.shipping_address ? $('#shipping_country').val(data.shipping_address.shipping_country.toUpperCase()) : '';
                 'shipping_state' in data.shipping_address ? $('#shipping_state').val(data.shipping_address.shipping_state) : '';
 
-                // extra shipping fields (email, phone).
+                // extra shipping fields (email, phone, name).
                 if (lco_wc.shippingEmailExists === true && $('#shipping_email')) {
                     $('#shipping_email').val((('shipping_email' in data.shipping_address) ? data.shipping_address.shipping_email : ''));
                 }
                 if (lco_wc.shippingPhoneExists === true && $('#shipping_phone')) {
                     $('#shipping_phone').val((('shipping_phone' in data.shipping_address) ? data.shipping_address.shipping_phone : ''));
+                }
+                if (lco_wc.shippingFirstNameExists === true && $('#shipping_first_name')) {
+                    $('#shipping_first_name').val((('shipping_first_name' in data.shipping_address) ? data.shipping_address.shipping_first_name : ''));
+                }
+                if (lco_wc.shippingLastNameExists === true && $('#shipping_last_name')) {
+                    $('#shipping_last_name').val((('shipping_last_name' in data.shipping_address) ? data.shipping_address.shipping_last_name : ''));
                 }
             }
         },

--- a/changelog.readme
+++ b/changelog.readme
@@ -1,3 +1,6 @@
+## 1.5.0 
+Feature: Show order recipient details in order overview
+
 ## 1.4.0 
 Feature: Allow custom shipping address contact details in settings
 

--- a/classes/admin/class-ledyer-meta-box.php
+++ b/classes/admin/class-ledyer-meta-box.php
@@ -93,10 +93,10 @@ class Meta_Box {
                     <strong><?php esc_html_e( 'Order setter: ', 'ledyer-checkout-for-woocommerce' ); ?> </strong> <?php echo esc_html( $ledyer_order['customer']['firstName'] . ' ' . $ledyer_order['customer']['lastName'] ); ?><br/>
 				<?php endif; ?>
 				<?php if( $ledyer_order['customer']['reference1'] ) : ?>
-                    <strong><?php esc_html_e( 'Customer referens 1: ', 'ledyer-checkout-for-woocommerce' ); ?> </strong> <?php echo esc_html( $ledyer_order['customer']['reference1'] ); ?><br/>
+                    <strong><?php esc_html_e( 'Invoice reference (e.g. order number): ', 'ledyer-checkout-for-woocommerce' ); ?> </strong> <?php echo esc_html( $ledyer_order['customer']['reference1'] ); ?><br/>
 				<?php endif; ?>
 				<?php if( $ledyer_order['customer']['reference2'] ) : ?>
-                    <strong><?php esc_html_e( 'Customer referens 2: ', 'ledyer-checkout-for-woocommerce' ); ?> </strong> <?php echo esc_html( $ledyer_order['customer']['reference2'] ); ?><br/>
+                    <strong><?php esc_html_e( 'Optional reference (e.g. cost center): ', 'ledyer-checkout-for-woocommerce' ); ?> </strong> <?php echo esc_html( $ledyer_order['customer']['reference2'] ); ?><br/>
 				<?php endif; ?>
 			<?php } ?>
         </div>

--- a/classes/class-ledyer-ajax.php
+++ b/classes/class-ledyer-ajax.php
@@ -186,14 +186,16 @@ class AJAX extends \WC_AJAX {
 
 				switch ( $key ) {
 					case 'billing_first_name':
-					case 'shipping_first_name':
 						$fields['billing_address'][ $key ]  = $ledyer_order['customer']['firstName'];
-						$fields['shipping_address'][ $key ] = $ledyer_order['customer']['firstName'];
+						break;
+					case 'shipping_first_name':
+						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['firstName'] : '';
 						break;
 					case 'billing_last_name':
-					case 'shipping_last_name':
 						$fields['billing_address'][ $key ]  = $ledyer_order['customer']['lastName'];
-						$fields['shipping_address'][ $key ] = $ledyer_order['customer']['lastName'];
+						break;
+					case 'shipping_last_name':
+						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['lastName'] : '';
 						break;
 					case 'billing_company':
 						$fields['billing_address'][ $key ] = isset( $ledyer_order['customer']['billingAddress'] ) ? $ledyer_order['customer']['billingAddress']['companyName'] : '';
@@ -230,6 +232,12 @@ class AJAX extends \WC_AJAX {
 						break;
 					case 'billing_email':
 						$fields['billing_address'][ $key ] = $ledyer_order['customer']['email'];
+						break;
+					case 'shipping_phone':
+						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['phone'] : '';
+						break;
+					case 'shipping_email':
+						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['email'] : '';
 						break;
 					default:
 						unset( $fields[ $key ] );

--- a/classes/class-ledyer-lco-gateway.php
+++ b/classes/class-ledyer-lco-gateway.php
@@ -66,8 +66,8 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			\add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'show_thank_you_snippet' ) );
 			\add_action( 'woocommerce_thankyou', 'lco_unset_sessions', 100, 1 );
 
-			\add_action('woocommerce_admin_order_data_after_billing_address', array( $this, 'ledyer_order_billing_fileds' ), 10, 1);
-			\add_action('woocommerce_admin_order_data_after_shipping_address', array( $this, 'ledyer_order_shipping_fileds' ), 10, 1);
+			\add_action('woocommerce_admin_order_data_after_billing_address', array( $this, 'ledyer_order_billing_fields' ), 10, 1);
+			\add_action('woocommerce_admin_order_data_after_shipping_address', array( $this, 'ledyer_order_shipping_fields' ), 10, 1);
 
 			\add_filter('woocommerce_formatted_address_replacements', array( $this, 'change_order_fields' ), 10, 2);
 		}
@@ -304,14 +304,17 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				$ledyer_country = wc_get_base_location()['country'];
 				update_post_meta( $order_id, '_wc_ledyer_country', $ledyer_country );
 
-				// Set shipping phone and email.
-				update_post_meta( $order_id, '_shipping_phone', sanitize_text_field( $ledyer_order['customer']['phone'] ) );
-				update_post_meta( $order_id, '_shipping_email', sanitize_text_field( $ledyer_order['customer']['email'] ) );
-
 				// Set shipping meta
 				if( isset( $ledyer_order['customer']['shippingAddress'] ) ) {
 					update_post_meta( $order_id, '_shipping_attention_name', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['attentionName'] ) );
 					update_post_meta( $order_id, '_shipping_care_of', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['careOf'] ) );
+				}
+				// Set order recipient meta
+				if( isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ) {
+					update_post_meta( $order_id, '_shipping_first_name', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['contact']["firstName"] ) );
+					update_post_meta( $order_id, '_shipping_last_name', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['contact']["lastName"]) );
+					update_post_meta( $order_id, '_shipping_phone', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['contact']["phone"] ) );
+					update_post_meta( $order_id, '_shipping_email', sanitize_text_field( $ledyer_order['customer']['shippingAddress']['contact']["email"]) );
 				}
 
 				// Set billing meta
@@ -426,7 +429,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 *
 		 * @return void
 		 */
-		public function ledyer_order_billing_fileds( $order ) {
+		public function ledyer_order_billing_fields( $order ) {
 
 			if ( 'Automattic\WooCommerce\Admin\Overrides\Order' === get_class( $order ) ) {
 				$order_id = $order->get_id();
@@ -451,7 +454,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 *
 		 * @return void
 		 */
-		public function ledyer_order_shipping_fileds( $order ) {
+		public function ledyer_order_shipping_fields( $order ) {
 
 			if ( 'Automattic\WooCommerce\Admin\Overrides\Order' === get_class( $order ) ) {
 				$order_id = $order->get_id();
@@ -461,6 +464,10 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 			$attention_name = get_post_meta( $order_id, '_shipping_attention_name', true );
 			$care_of        = get_post_meta( $order_id, '_shipping_care_of', true );
+			$first_name     = get_post_meta( $order_id, '_shipping_first_name', true );
+			$last_name      = get_post_meta( $order_id, '_shipping_last_name', true );
+			$phone			= get_post_meta( $order_id, '_shipping_phone', true );
+			$email	      	= get_post_meta( $order_id, '_shipping_email', true );
 
 			if ( ! empty( $attention_name ) ) {
 				echo '<p><strong>' . __( 'Shipping Attention Name' ) . ':</strong><br> ' . esc_html($attention_name) . '</p>';
@@ -468,6 +475,18 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 			if ( ! empty( $care_of ) ) {
 				echo '<p><strong>' . __( 'Shipping Care Of' ) . ':</strong><br> ' . esc_html($care_of) . '</p>';
+			}
+
+			if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
+				echo '<p><strong>' . __( 'Order Recipient Name' ) . ':</strong><br> ' . esc_html($first_name) . ' ' . esc_html($last_name) . '</p>';
+			}
+
+			if ( ! empty( $phone )  ) {
+				echo '<p><strong>' . __( 'Order Recipient Phone' ) . ':</strong><br> ' . esc_html($phone) . '</p>';
+			}
+
+			if ( ! empty( $email ) ) {
+				echo '<p><strong>' . __( 'Order Recipient Email' ) . ':</strong><br> ' . esc_html($email) . '</p>';
 			}
 		}
 

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -51,7 +51,7 @@ class Ledyer_Checkout_For_WooCommerce {
 	 */
 	public $checkout;
 
-	const VERSION = '1.4.0';
+	const VERSION = '1.5.0';
 	const SLUG = 'ledyer-checkout-for-woocommerce';
 	const SETTINGS = 'ledyer_checkout_for_woocommerce_settings';
 

--- a/languages/ledyer-checkout-for-woocommerce.pot
+++ b/languages/ledyer-checkout-for-woocommerce.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Ledyer Checkout for WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Ledyer Checkout for WooCommerce 1.4.0\n"
+"Project-Id-Version: Ledyer Checkout for WooCommerce 1.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/ledyer-checkout-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/ledyer-checkout-for-woocommerce.php
+++ b/ledyer-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Ledyer Checkout payment gateway for WooCommerce.
  * Author: Maksimer/Ledyer
  * Author URI: https://www.maksimer.com/
- * Version: 1.4.0
+ * Version: 1.5.0
  * Text Domain: ledyer-checkout-for-woocommerce
  * Domain Path: /languages
  *

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 8.1.11
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Result

<img width="1030" alt="image" src="https://user-images.githubusercontent.com/2391754/218262369-c1dad3fa-125a-4ec0-9840-e6ecfbeea618.png">

## Further info

It seems like WooCommerce provides support with functions for getting shipping contact details out of the box, if you name the fields according to a pattern. So I followed the same pattern that was half implemented for the already existing contact fields (email and phone)

https://woocommerce.github.io/code-reference/classes/WC-Customer.html

<img width="331" alt="image" src="https://user-images.githubusercontent.com/2391754/218262948-818db79c-355d-4d2f-a221-516368578c4a.png">
