### PR TITLE
fix/Correct latest wp version tested in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: maksimer, ledyer
 Tags: woocommerce, ledyer, ecommerce, e-commerce, checkout
 Donate link: https://ledyer.com
 Requires at least: 4.0
-Tested up to: 8.1.11
+Tested up to: 6.2
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3


### PR DESCRIPTION
Wrong version tag was set for latest wp-version tested so we got a warning that our plugin wasn't maintained

<img width="997" alt="Screenshot 2023-04-06 at 10 05 37" src="https://user-images.githubusercontent.com/7665542/230314067-b0b6fbee-f7f9-4810-8f3a-3ac5f34f6336.png">
