### PR TITLE
temp set version manually to 1.7.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,11 @@
+## 1.7.1
+
+* Version fix, last release got 0.0.0-development as release number
+
+## 1.7.0
+
+* CI updates
+
 ## 1.6.8
 
 * Fix: Revert to woocommerce_process_shop_order_meta hook but give it a higher priority.

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -51,7 +51,7 @@ class Ledyer_Checkout_For_WooCommerce {
 	 */
 	public $checkout;
 
-	const VERSION = '0.0.0-development';
+	const VERSION = '1.7.1';
 	const SLUG = 'ledyer-checkout-for-woocommerce';
 	const SETTINGS = 'ledyer_checkout_for_woocommerce_settings';
 

--- a/languages/ledyer-checkout-for-woocommerce.pot
+++ b/languages/ledyer-checkout-for-woocommerce.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Ledyer Checkout for WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Ledyer Checkout for WooCommerce 0.0.0-development\n"
+"Project-Id-Version: Ledyer Checkout for WooCommerce 1.7.1"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/ledyer-checkout-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/ledyer-checkout-for-woocommerce.php
+++ b/ledyer-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Ledyer Checkout payment gateway for WooCommerce.
  * Author: Maksimer/Ledyer
  * Author URI: https://www.maksimer.com/
- * Version: 0.0.0-development
+ * Version: 1.7.1
  * Text Domain: ledyer-checkout-for-woocommerce
  * Domain Path: /languages
  *

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 6.2
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 6.9.3
-Stable tag: 0.0.0-development
+Stable tag: 1.7.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Had to do a manual release of 1.7.1 after accidentally releaseing 1.7.0 but with all versions set to `0.0.0-development`.
Will merge this, create a git-tag manually, then revert this in main.