### PR TITLE
fix: remove first of duplicate orderNotes field

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,138 +1,146 @@
+## 1.7.7
+
+- Only take first order notes field into lco-extra-checkout-fields
+
+## 1.7.6
+
+- Version bump
+
 ## 1.7.5
 
-* Version bump
+- Version bump
 
 ## 1.7.4
 
-* Remove empty fields form fields
+- Remove empty fields form fields
 
 ## 1.7.3
 
-* Add element container for extra fields, to deal with Cartflows
+- Add element container for extra fields, to deal with Cartflows
 
 ## 1.7.2
 
-* Adjustment for Cartflows
+- Adjustment for Cartflows
 
 ## 1.7.1
 
-* Version fix, last release got 0.0.0-development as release number
+- Version fix, last release got 0.0.0-development as release number
 
 ## 1.7.0
 
-* CI updates
+- CI updates
 
 ## 1.6.8
 
-* Fix: Revert to woocommerce_process_shop_order_meta hook but give it a higher priority.
+- Fix: Revert to woocommerce_process_shop_order_meta hook but give it a higher priority.
 
 ## 1.6.7
 
-* Feat: Add validation of order meta data (moved from O.M. plugin)
-* Feat: Implement local email address validation of order meta data
-* Fix: Use save_post hook to update order meta data
+- Feat: Add validation of order meta data (moved from O.M. plugin)
+- Feat: Implement local email address validation of order meta data
+- Fix: Use save_post hook to update order meta data
 
 ## 1.6.6
 
-* Fix: Prevent multiple orders
+- Fix: Prevent multiple orders
 
 ## 1.6.5
 
-* Fix: Payment method titles
-* Fix: Change to use exclusive vat mode
+- Fix: Payment method titles
+- Fix: Change to use exclusive vat mode
 
 ## 1.6.4
 
-* Fix: Discount rounding issue
-* Fix: Show billing and shipping name
+- Fix: Discount rounding issue
+- Fix: Show billing and shipping name
 
 ## 1.6.3
 
-* Fix: Rounding issue
+- Fix: Rounding issue
 
 ## 1.6.2
 
-* Chore: version bump
+- Chore: version bump
 
 ## 1.6.1
 
-* Fix: Added invoice email
-* Fix: Corrected latest WP version
+- Fix: Added invoice email
+- Fix: Corrected latest WP version
 
 ## 1.6.0
 
-* Feature: make custom address fields editable
+- Feature: make custom address fields editable
 
 ## 1.5.2
 
-* Fix: Use order number as reference
-* Fix: Added last updated to Ledyer order info
-* Fix: Prevent duplicate orders for some cases
-* Fix: Coupon and giftcard adjustments
+- Fix: Use order number as reference
+- Fix: Added last updated to Ledyer order info
+- Fix: Prevent duplicate orders for some cases
+- Fix: Coupon and giftcard adjustments
 
 ## 1.5.1
 
-* Fix: Adjusted Ledyer order info box
+- Fix: Adjusted Ledyer order info box
 
 ## 1.5.0
 
-* Feature: Show order recipient details in order overview
+- Feature: Show order recipient details in order overview
 
 ## 1.4.0
 
-* Feature: Allow custom shipping address contact details in settings
+- Feature: Allow custom shipping address contact details in settings
 
 ## 1.3.1
 
-* Fix: Testmode patch and separate test token
+- Fix: Testmode patch and separate test token
 
 ## 1.3.0
 
-* Feature: Activate Refund using Ledyer and listen for refund and pass to order management
+- Feature: Activate Refund using Ledyer and listen for refund and pass to order management
 
 ## 1.2.1
 
-* Fix: prevent multiple notes
+- Fix: prevent multiple notes
 
 ## 1.2.0
 
-* Fix: Notifications handling and basic order management
+- Fix: Notifications handling and basic order management
 
 ## 1.1.3
 
-* Fix: Sanitize response url query parameters (wp review)
-* Fix: Escape variables that we print in html markup
-* Manually specify imported classes
-* Stable tag, same as latest version in readme.txt
+- Fix: Sanitize response url query parameters (wp review)
+- Fix: Escape variables that we print in html markup
+- Manually specify imported classes
+- Stable tag, same as latest version in readme.txt
 
 # 1.1.2
 
-* Fix: prevent duplicate orders from being placed
+- Fix: prevent duplicate orders from being placed
 
 ## 1.1.1
 
-* Fix: client side validation bugs
+- Fix: client side validation bugs
 
 ## 1.1.0
 
-* Feature: client side validation
+- Feature: client side validation
 
 ## 1.0.4
 
-* Bugfix: php8
+- Bugfix: php8
 
 ## 1.0.3
 
-* Bugfix: repair discount/coupon functionality
+- Bugfix: repair discount/coupon functionality
 
 ## 1.0.2
 
-* Bugfix: billing and shipping address. Use streetAddress, not country
+- Bugfix: billing and shipping address. Use streetAddress, not country
 
 ## 1.0.1
 
-* Bugfix: center iframe; 100% width and place checkout below shipping
+- Bugfix: center iframe; 100% width and place checkout below shipping
 
 ## 1.0.0
 
-* Initial project setup
+- Initial project setup

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 ## 1.7.7
 
-- Only take first order notes field into lco-extra-checkout-fields
+- Strip first order notes field when there are more than one
 
 ## 1.7.6
 

--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -137,10 +137,14 @@ jQuery(function ($) {
      * Moves all non standard fields to the extra checkout fields.
      */
     moveExtraCheckoutFields: function () {
+      if (document.querySelectorAll("#order_comments_field").length > 1) {
+        document.querySelector("#order_comments_field").remove();
+      }
+
       // Move order comments.
-      $(".woocommerce-additional-fields")
-        .first()
-        .appendTo("#lco-extra-checkout-fields");
+      $(".woocommerce-additional-fields").appendTo(
+        "#lco-extra-checkout-fields"
+      );
       var form = $(
         'form[name="checkout"] input, form[name="checkout"] select, textarea'
       );

--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -1,491 +1,606 @@
 /* global lco_params */
 
 jQuery(function ($) {
+  // Check if we have params.
+  if ("undefined" === typeof lco_params) {
+    return false;
+  }
 
-    // Check if we have params.
-    if ('undefined' === typeof lco_params) {
-        return false;
-    }
+  var lco_wc = {
+    bodyEl: $("body"),
+    checkoutFormSelector: $("form.checkout"),
 
-    var lco_wc = {
-        bodyEl: $('body'),
-        checkoutFormSelector: $('form.checkout'),
+    // Payment method.
+    paymentMethodEl: $('input[name="payment_method"]'),
+    paymentMethod: "",
+    selectAnotherSelector: "#ledyer-checkout-select-other",
 
-        // Payment method.
-        paymentMethodEl: $('input[name="payment_method"]'),
-        paymentMethod: '',
-        selectAnotherSelector: '#ledyer-checkout-select-other',
+    // Form fields.
+    shippingUpdated: false,
+    blocked: false,
 
-        // Form fields.
-        shippingUpdated: false,
-        blocked: false,
+    preventPaymentMethodChange: false,
 
-        preventPaymentMethodChange: false,
+    timeout: null,
+    interval: null,
 
-        timeout: null,
-        interval: null,
+    // True or false if we need to update the Ledyer order. Set to false on initial page load.
+    ledyerUpdateNeeded: false,
+    shippingEmailExists: false,
+    shippingPhoneExists: false,
+    shippingFirstNameExists: false,
+    shippingLastNameExists: false,
 
-        // True or false if we need to update the Ledyer order. Set to false on initial page load.
-        ledyerUpdateNeeded: false,
-        shippingEmailExists: false,
-        shippingPhoneExists: false,
-        shippingFirstNameExists: false,
-        shippingLastNameExists: false,
+    /**
+     * Triggers on document ready.
+     */
+    documentReady: function () {
+      if (0 < lco_wc.paymentMethodEl.length) {
+        lco_wc.paymentMethod = lco_wc.paymentMethodEl.filter(":checked").val();
+      } else {
+        lco_wc.paymentMethod = "lco";
+      }
 
-        /**
-         * Triggers on document ready.
-         */
-        documentReady: function () {
-            if (0 < lco_wc.paymentMethodEl.length) {
-                lco_wc.paymentMethod = lco_wc.paymentMethodEl.filter(':checked').val();
-            } else {
-                lco_wc.paymentMethod = 'lco';
+      if ("lco" === lco_wc.paymentMethod) {
+        $("#ship-to-different-address-checkbox").prop("checked", true);
+      }
+
+      if (!lco_params.pay_for_order) {
+        lco_wc.moveExtraCheckoutFields();
+      }
+    },
+
+    /**
+     * Suspends the Ledyer Iframe
+     */
+    lcoSuspend: function () {
+      if (window.ledyer) {
+        window.ledyer.api.suspend();
+      }
+    },
+
+    /**
+     * Resumes the LCO Iframe
+     */
+    lcoResume: function () {
+      if (window.ledyer) {
+        window.ledyer.api.resume();
+      }
+    },
+
+    /**
+     * When the customer changes from LCO to other payment methods.
+     * @param {Event} e
+     */
+    changeFromLco: function (e) {
+      e.preventDefault();
+
+      $(lco_wc.checkoutFormSelector).block({
+        message: null,
+        overlayCSS: {
+          background: "#fff",
+          opacity: 0.6,
+        },
+      });
+
+      $.ajax({
+        type: "POST",
+        dataType: "json",
+        data: {
+          lco: false,
+          nonce: lco_params.change_payment_method_nonce,
+        },
+        url: lco_params.change_payment_method_url,
+        success: function (data) {},
+        error: function (data) {},
+        complete: function (data) {
+          window.location.href = data.responseJSON.data.redirect;
+        },
+      });
+    },
+
+    /**
+     * When the customer changes to LCO from other payment methods.
+     */
+    maybeChangeToLco: function () {
+      if (!lco_wc.preventPaymentMethodChange) {
+        if ("lco" === $(this).val()) {
+          $(".woocommerce-info").remove();
+
+          $(lco_wc.checkoutFormSelector).block({
+            message: null,
+            overlayCSS: {
+              background: "#fff",
+              opacity: 0.6,
+            },
+          });
+
+          $.ajax({
+            type: "POST",
+            data: {
+              lco: true,
+              nonce: lco_params.change_payment_method_nonce,
+            },
+            dataType: "json",
+            url: lco_params.change_payment_method_url,
+            success: function (data) {},
+            error: function (data) {},
+            complete: function (data) {
+              window.location.href = data.responseJSON.data.redirect;
+            },
+          });
+        }
+      }
+    },
+
+    /**
+     * Moves all non standard fields to the extra checkout fields.
+     */
+    moveExtraCheckoutFields: function () {
+      // Move order comments.
+      $(".woocommerce-additional-fields")
+        .first()
+        .appendTo("#lco-extra-checkout-fields");
+      var form = $(
+        'form[name="checkout"] input, form[name="checkout"] select, textarea'
+      );
+      var checkout_add_ons_moved = false;
+      for (i = 0; i < form.length; i++) {
+        var name = form[i].name.replace("[]", "\\[\\]"); // Escape any empty "array" keys to prevent errors.
+        // Check if field is inside the order review.
+        if (
+          $("table.woocommerce-checkout-review-order-table").find(form[i])
+            .length
+        ) {
+          continue;
+        }
+
+        // Check if this is a standard field.
+        if (-1 === $.inArray(name, lco_params.standard_woo_checkout_fields)) {
+          // This is not a standard Woo field, move to our div.
+          if (
+            "wc_checkout_add_ons" ===
+            $("p#" + name + "_field")
+              .parent()
+              .attr("id")
+          ) {
+            // Check if this is an add on field.
+            if (!checkout_add_ons_moved) {
+              checkout_add_ons_moved = true;
+              $("div#wc_checkout_add_ons").appendTo(
+                "#lco-extra-checkout-fields"
+              );
             }
-
-            if ('lco' === lco_wc.paymentMethod) {
-                $('#ship-to-different-address-checkbox').prop('checked', true);
+          } else if (0 < $("p#" + name + "_field").length) {
+            if (name === "shipping_phone") {
+              lco_wc.shippingPhoneExists = true;
             }
-
-            if (!lco_params.pay_for_order) {
-                lco_wc.moveExtraCheckoutFields();
+            if (name === "shipping_email") {
+              lco_wc.shippingEmailExists = true;
             }
-        },
-
-        /**
-         * Suspends the Ledyer Iframe
-         */
-        lcoSuspend: function () {
-            if (window.ledyer) {
-                window.ledyer.api.suspend();
+            if (name === "shipping_first_name") {
+              lco_wc.shippingFirstNameExists = true;
             }
-        },
-
-        /**
-         * Resumes the LCO Iframe
-         */
-        lcoResume: function () {
-            if (window.ledyer) {
-                window.ledyer.api.resume();
+            if (name === "shipping_last_name") {
+              lco_wc.shippingLastNameExists = true;
             }
+            $("p#" + name + "_field").appendTo("#lco-extra-checkout-fields");
+          } else {
+            $('input[name="' + name + '"]')
+              .closest("p")
+              .appendTo("#lco-extra-checkout-fields");
+          }
+        }
+      }
+    },
+
+    /**
+     * Updates the cart in case of a change in product quantity.
+     */
+    updateCart: function () {
+      lco_wc.lcoSuspend(true);
+      $.ajax({
+        type: "POST",
+        url: lco_params.update_cart_url,
+        data: {
+          checkout: lco_wc.cleanupForm($("form.checkout")),
+          nonce: lco_params.update_cart_nonce,
         },
-
-        /**
-         * When the customer changes from LCO to other payment methods.
-         * @param {Event} e
-         */
-        changeFromLco: function (e) {
-            e.preventDefault();
-
-            $(lco_wc.checkoutFormSelector).block({
-                message: null,
-                overlayCSS: {
-                    background: '#fff',
-                    opacity: 0.6
-                }
-            });
-
-            $.ajax({
-                type: 'POST',
-                dataType: 'json',
-                data: {
-                    lco: false,
-                    nonce: lco_params.change_payment_method_nonce
-                },
-                url: lco_params.change_payment_method_url,
-                success: function (data) { },
-                error: function (data) { },
-                complete: function (data) {
-                    window.location.href = data.responseJSON.data.redirect;
-                }
-            });
+        dataType: "json",
+        success: function (data) {},
+        error: function (data) {},
+        complete: function (data) {
+          $("body").trigger("update_checkout");
+          lco_wc.lcoResume();
         },
+      });
+    },
 
-        /**
-         * When the customer changes to LCO from other payment methods.
-         */
-        maybeChangeToLco: function () {
-            if (!lco_wc.preventPaymentMethodChange) {
-
-                if ('lco' === $(this).val()) {
-                    $('.woocommerce-info').remove();
-
-                    $(lco_wc.checkoutFormSelector).block({
-                        message: null,
-                        overlayCSS: {
-                            background: '#fff',
-                            opacity: 0.6
-                        }
-                    });
-
-                    $.ajax({
-                        type: 'POST',
-                        data: {
-                            lco: true,
-                            nonce: lco_params.change_payment_method_nonce
-                        },
-                        dataType: 'json',
-                        url: lco_params.change_payment_method_url,
-                        success: function (data) { },
-                        error: function (data) { },
-                        complete: function (data) {
-                            window.location.href = data.responseJSON.data.redirect;
-                        }
-                    });
-                }
-            }
+    /**
+     * Gets the Ledyer order and starts the order submission
+     */
+    getLedyerOrder: function () {
+      lco_wc.preventPaymentMethodChange = true;
+      $(".woocommerce-checkout-review-order-table").block({
+        message: null,
+        overlayCSS: {
+          background: "#fff",
+          opacity: 0.6,
         },
+      });
 
-        /**
-         * Moves all non standard fields to the extra checkout fields.
-         */
-        moveExtraCheckoutFields: function () {
-
-            // Move order comments.
-            $('.woocommerce-additional-fields').appendTo('#lco-extra-checkout-fields');
-            var form = $('form[name="checkout"] input, form[name="checkout"] select, textarea');
-            var checkout_add_ons_moved = false;
-            for (i = 0; i < form.length; i++) {
-                var name = form[i].name.replace('[]', '\\[\\]'); // Escape any empty "array" keys to prevent errors.
-                // Check if field is inside the order review.
-                if ($('table.woocommerce-checkout-review-order-table').find(form[i]).length) {
-                    continue;
-                }
-
-                // Check if this is a standard field.
-                if (-1 === $.inArray(name, lco_params.standard_woo_checkout_fields)) {
-                    // This is not a standard Woo field, move to our div.
-                    if ('wc_checkout_add_ons' === $('p#' + name + '_field').parent().attr('id')) { // Check if this is an add on field.
-                        if (!checkout_add_ons_moved) {
-                            checkout_add_ons_moved = true;
-                            $('div#wc_checkout_add_ons').appendTo('#lco-extra-checkout-fields');
-                        }
-                    } else if (0 < $('p#' + name + '_field').length) {
-                        if (name === 'shipping_phone') {
-                            lco_wc.shippingPhoneExists = true;
-                        }
-                        if (name === 'shipping_email') {
-                            lco_wc.shippingEmailExists = true;
-                        }
-                        if (name === 'shipping_first_name') {
-                            lco_wc.shippingFirstNameExists = true;
-                        }
-                        if (name === 'shipping_last_name') {
-                            lco_wc.shippingLastNameExists = true;
-                        }
-                        $('p#' + name + '_field').appendTo('#lco-extra-checkout-fields');
-                    } else {
-                        $('input[name="' + name + '"]').closest('p').appendTo('#lco-extra-checkout-fields');
-                    }
-                }
-            }
+      var ajax = $.ajax({
+        type: "POST",
+        url: lco_params.get_ledyer_order_url,
+        data: {
+          nonce: lco_params.get_ledyer_order_nonce,
         },
+        dataType: "json",
+        success: function (data) {
+          lco_wc.setCustomerData(data.data);
 
-        /**
-         * Updates the cart in case of a change in product quantity.
-         */
-        updateCart: function () {
-            lco_wc.lcoSuspend(true);
-            $.ajax({
-                type: 'POST',
-                url: lco_params.update_cart_url,
-                data: {
-                    checkout: lco_wc.cleanupForm($('form.checkout')),
-                    nonce: lco_params.update_cart_nonce
-                },
-                dataType: 'json',
-                success: function (data) {
-                },
-                error: function (data) {
-                },
-                complete: function (data) {
-                    $('body').trigger('update_checkout');
-                    lco_wc.lcoResume();
-                }
-            });
+          // Check Terms checkbox, if it exists.
+          if (0 < $("form.checkout #terms").length) {
+            $("form.checkout #terms").prop("checked", true);
+          }
         },
+        error: function (data) {},
+        complete: function (data) {},
+      });
 
-        /**
-         * Gets the Ledyer order and starts the order submission
-         */
-        getLedyerOrder: function () {
-            lco_wc.preventPaymentMethodChange = true;
-            $('.woocommerce-checkout-review-order-table').block({
-                message: null,
-                overlayCSS: {
-                    background: '#fff',
-                    opacity: 0.6
-                }
-            });
+      return ajax;
+    },
 
-            var ajax = $.ajax({
-                type: 'POST',
-                url: lco_params.get_ledyer_order_url,
-                data: {
-                    nonce: lco_params.get_ledyer_order_nonce
-                },
-                dataType: 'json',
-                success: function (data) {
-                    lco_wc.setCustomerData(data.data);
+    /**
+     * Sets the customer data.
+     * @param {array} data
+     */
+    setCustomerData: function (data) {
+      if ("billing_address" in data && data.billing_address !== null) {
+        // Billing fields.
+        "billing_first_name" in data.billing_address
+          ? $("#billing_first_name").val(
+              data.billing_address.billing_first_name
+            )
+          : "";
+        "billing_last_name" in data.billing_address
+          ? $("#billing_last_name").val(data.billing_address.billing_last_name)
+          : "";
+        "billing_company" in data.billing_address
+          ? $("#billing_company").val(data.billing_address.billing_company)
+          : "";
+        "billing_address_1" in data.billing_address
+          ? $("#billing_address_1").val(data.billing_address.billing_address_1)
+          : "";
+        "billing_address_2" in data.billing_address
+          ? $("#billing_address_2").val(data.billing_address.billing_address_2)
+          : "";
+        "billing_city" in data.billing_address
+          ? $("#billing_city").val(data.billing_address.billing_city)
+          : "";
+        "billing_postcode" in data.billing_address
+          ? $("#billing_postcode").val(data.billing_address.billing_postcode)
+          : "";
+        "billing_phone" in data.billing_address
+          ? $("#billing_phone").val(data.billing_address.billing_phone)
+          : "";
+        "billing_email" in data.billing_address
+          ? $("#billing_email").val(data.billing_address.billing_email)
+          : "";
+        "billing_country" in data.billing_address
+          ? $("#billing_country").val(
+              data.billing_address.billing_country.toUpperCase()
+            )
+          : "";
+        "billing_state" in data.billing_address
+          ? $("#billing_state").val(data.billing_address.billing_state)
+          : "";
+        // Trigger changes
+        $("#billing_email").change();
+        $("#billing_email").blur();
+      }
 
-                    // Check Terms checkbox, if it exists.
-                    if (0 < $('form.checkout #terms').length) {
-                        $('form.checkout #terms').prop('checked', true);
-                    }
-                },
-                error: function (data) {
+      if ("shipping_address" in data && data.shipping_address !== null) {
+        $("#ship-to-different-address-checkbox").prop("checked", true);
 
-                },
-                complete: function (data) {
-                }
-            });
+        // Shipping fields.
+        "shipping_first_name" in data.shipping_address
+          ? $("#shipping_first_name").val(
+              data.shipping_address.shipping_first_name
+            )
+          : "";
+        "shipping_last_name" in data.shipping_address
+          ? $("#shipping_last_name").val(
+              data.shipping_address.shipping_last_name
+            )
+          : "";
+        "shipping_company" in data.shipping_address
+          ? $("#shipping_company").val(data.shipping_address.shipping_company)
+          : "";
+        "shipping_address_1" in data.shipping_address
+          ? $("#shipping_address_1").val(
+              data.shipping_address.shipping_address_1
+            )
+          : "";
+        "shipping_address_2" in data.shipping_address
+          ? $("#shipping_address_2").val(
+              data.shipping_address.shipping_address_2
+            )
+          : "";
+        "shipping_city" in data.shipping_address
+          ? $("#shipping_city").val(data.shipping_address.shipping_city)
+          : "";
+        "shipping_postcode" in data.shipping_address
+          ? $("#shipping_postcode").val(data.shipping_address.shipping_postcode)
+          : "";
+        "shipping_country" in data.shipping_address
+          ? $("#shipping_country").val(
+              data.shipping_address.shipping_country.toUpperCase()
+            )
+          : "";
+        "shipping_state" in data.shipping_address
+          ? $("#shipping_state").val(data.shipping_address.shipping_state)
+          : "";
 
-            return ajax;
+        // extra shipping fields (email, phone, name).
+        if (lco_wc.shippingEmailExists === true && $("#shipping_email")) {
+          $("#shipping_email").val(
+            "shipping_email" in data.shipping_address
+              ? data.shipping_address.shipping_email
+              : ""
+          );
+        }
+        if (lco_wc.shippingPhoneExists === true && $("#shipping_phone")) {
+          $("#shipping_phone").val(
+            "shipping_phone" in data.shipping_address
+              ? data.shipping_address.shipping_phone
+              : ""
+          );
+        }
+        if (
+          lco_wc.shippingFirstNameExists === true &&
+          $("#shipping_first_name")
+        ) {
+          $("#shipping_first_name").val(
+            "shipping_first_name" in data.shipping_address
+              ? data.shipping_address.shipping_first_name
+              : ""
+          );
+        }
+        if (
+          lco_wc.shippingLastNameExists === true &&
+          $("#shipping_last_name")
+        ) {
+          $("#shipping_last_name").val(
+            "shipping_last_name" in data.shipping_address
+              ? data.shipping_address.shipping_last_name
+              : ""
+          );
+        }
+      }
+    },
+
+    /**
+     * Logs the message to the ledyer checkout log in WooCommerce.
+     * @param {string} message
+     */
+    logToFile: function (message) {
+      $.ajax({
+        url: lco_params.log_to_file_url,
+        type: "POST",
+        dataType: "json",
+        data: {
+          message: message,
+          nonce: lco_params.log_to_file_nonce,
         },
+      });
+    },
 
+    /**
+     * Logs messages to the console.
+     * @param {string} message
+     */
+    log: function (message) {
+      if (lco_params.logging) {
+        console.log(message);
+      }
+    },
 
-        /**
-         * Sets the customer data.
-         * @param {array} data
-         */
-        setCustomerData: function (data) {
-            if ('billing_address' in data && data.billing_address !== null) {
-                // Billing fields.
-                'billing_first_name' in data.billing_address ? $('#billing_first_name').val(data.billing_address.billing_first_name) : '';
-                'billing_last_name' in data.billing_address ? $('#billing_last_name').val(data.billing_address.billing_last_name) : '';
-                'billing_company' in data.billing_address ? $('#billing_company').val(data.billing_address.billing_company) : '';
-                'billing_address_1' in data.billing_address ? $('#billing_address_1').val(data.billing_address.billing_address_1) : '';
-                'billing_address_2' in data.billing_address ? $('#billing_address_2').val(data.billing_address.billing_address_2) : '';
-                'billing_city' in data.billing_address ? $('#billing_city').val(data.billing_address.billing_city) : '';
-                'billing_postcode' in data.billing_address ? $('#billing_postcode').val(data.billing_address.billing_postcode) : '';
-                'billing_phone' in data.billing_address ? $('#billing_phone').val(data.billing_address.billing_phone) : '';
-                'billing_email' in data.billing_address ? $('#billing_email').val(data.billing_address.billing_email) : '';
-                'billing_country' in data.billing_address ? $('#billing_country').val(data.billing_address.billing_country.toUpperCase()) : '';
-                'billing_state' in data.billing_address ? $('#billing_state').val(data.billing_address.billing_state) : '';
-                // Trigger changes
-                $('#billing_email').change();
-                $('#billing_email').blur();
-            }
-
-            if ('shipping_address' in data && data.shipping_address !== null) {
-                $('#ship-to-different-address-checkbox').prop('checked', true);
-
-                // Shipping fields.
-                'shipping_first_name' in data.shipping_address ? $('#shipping_first_name').val(data.shipping_address.shipping_first_name) : '';
-                'shipping_last_name' in data.shipping_address ? $('#shipping_last_name').val(data.shipping_address.shipping_last_name) : '';
-                'shipping_company' in data.shipping_address ? $('#shipping_company').val(data.shipping_address.shipping_company) : '';
-                'shipping_address_1' in data.shipping_address ? $('#shipping_address_1').val(data.shipping_address.shipping_address_1) : '';
-                'shipping_address_2' in data.shipping_address ? $('#shipping_address_2').val(data.shipping_address.shipping_address_2) : '';
-                'shipping_city' in data.shipping_address ? $('#shipping_city').val(data.shipping_address.shipping_city) : '';
-                'shipping_postcode' in data.shipping_address ? $('#shipping_postcode').val(data.shipping_address.shipping_postcode) : '';
-                'shipping_country' in data.shipping_address ? $('#shipping_country').val(data.shipping_address.shipping_country.toUpperCase()) : '';
-                'shipping_state' in data.shipping_address ? $('#shipping_state').val(data.shipping_address.shipping_state) : '';
-
-                // extra shipping fields (email, phone, name).
-                if (lco_wc.shippingEmailExists === true && $('#shipping_email')) {
-                    $('#shipping_email').val((('shipping_email' in data.shipping_address) ? data.shipping_address.shipping_email : ''));
-                }
-                if (lco_wc.shippingPhoneExists === true && $('#shipping_phone')) {
-                    $('#shipping_phone').val((('shipping_phone' in data.shipping_address) ? data.shipping_address.shipping_phone : ''));
-                }
-                if (lco_wc.shippingFirstNameExists === true && $('#shipping_first_name')) {
-                    $('#shipping_first_name').val((('shipping_first_name' in data.shipping_address) ? data.shipping_address.shipping_first_name : ''));
-                }
-                if (lco_wc.shippingLastNameExists === true && $('#shipping_last_name')) {
-                    $('#shipping_last_name').val((('shipping_last_name' in data.shipping_address) ? data.shipping_address.shipping_last_name : ''));
-                }
-            }
+    /**
+     * Fails the Ledyer order.
+     * @param {string} error_message
+     */
+    failOrder: function (
+      error_message = "Kunde inte slutföra ordern. Var god försök igen. Om problemet kvarstår, vänligen kontakta kundsupport.",
+      alert = null
+    ) {
+      window.ledyer.api.clientValidation({
+        shouldProceed: false,
+        message: {
+          title: null, // Use default title in Ledyer checkout
+          body: error_message,
         },
+      });
 
-        /**
-         * Logs the message to the ledyer checkout log in WooCommerce.
-         * @param {string} message
-         */
-        logToFile: function (message) {
-            $.ajax(
-                {
-                    url: lco_params.log_to_file_url,
-                    type: 'POST',
-                    dataType: 'json',
-                    data: {
-                        message: message,
-                        nonce: lco_params.log_to_file_nonce
-                    }
-                }
-            );
+      const className = lco_params.pay_for_order
+        ? "div.woocommerce-notices-wrapper"
+        : "form.checkout";
+
+      // Update the checkout and reenable the form.
+      $("body").trigger("update_checkout");
+
+      const alert_message = alert ?? error_message;
+      const error_div = `<div class="woocommerce-error">${alert_message}</div>`;
+
+      // Print error messages, and trigger checkout_error, and scroll to notices.
+      $(
+        ".woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message"
+      ).remove();
+      $(className).prepend(
+        `<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"> ${error_div} </div>`
+      );
+      $(className).removeClass("processing").unblock();
+      $(className)
+        .find(".input-text, select, input:checkbox")
+        .trigger("validate")
+        .blur();
+      $(document.body).trigger("checkout_error", [alert_message]);
+      $("html, body").animate(
+        {
+          scrollTop: $(className).offset().top - 100,
         },
+        1000
+      );
+    },
 
-        /**
-         * Logs messages to the console.
-         * @param {string} message
-         */
-        log: function (message) {
-            if (lco_params.logging) {
-                console.log(message);
-            }
-        },
+    cleanupForm: function (formElement) {
+      const $inputs = formElement.find("input, select, textarea");
+      // remove inputs with empty values
+      const $inputsWithValue = $inputs.filter(function () {
+        return $(this).val() !== "";
+      });
+      const serializedData = $inputsWithValue.serialize();
 
-        /**
-         * Fails the Ledyer order.
-         * @param {string} error_message
-         */
-        failOrder: function (error_message = "Kunde inte slutföra ordern. Var god försök igen. Om problemet kvarstår, vänligen kontakta kundsupport.", alert = null) {
-            window.ledyer.api.clientValidation({
-                shouldProceed: false,
-                message: {
-                    title: null, // Use default title in Ledyer checkout
-                    body: error_message
-                }
-            })
+      return serializedData;
+    },
 
-            const className = lco_params.pay_for_order ? 'div.woocommerce-notices-wrapper' : 'form.checkout';
+    /**
+     * Places the Ledyer order
+     * @param {string} should_validate
+     */
+    placeLedyerOrder: function (should_validate = false) {
+      lco_wc.blocked = true;
+      lco_wc.getLedyerOrder().done(function (response) {
+        if (response.success) {
+          $(".woocommerce-checkout-review-order-table").block({
+            message: null,
+            overlayCSS: {
+              background: "#fff",
+              opacity: 0.6,
+            },
+          });
 
-            // Update the checkout and reenable the form.
-            $('body').trigger('update_checkout');
+          sessionStorage.removeItem("ledyerWooRedirectUrl");
 
-            const alert_message = alert ?? error_message;
-            const error_div = `<div class="woocommerce-error">${alert_message}</div>`;
+          $.ajax({
+            type: "POST",
+            url: lco_params.submit_order,
+            data: lco_wc.cleanupForm($("form.checkout")),
+            dataType: "json",
+            success: function (data) {
+              // data is an object with the following properties:
+              // { result: "success" | "failure"; refresh: "boolean", reload: boolean, messages: string; }
+              try {
+                if ("success" === data.result) {
+                  lco_wc.logToFile(
+                    "Successfully created order in WooCommerce."
+                  );
+                  const url = new URL(data.redirect);
+                  sessionStorage.setItem("ledyerWooRedirectUrl", url);
 
-            // Print error messages, and trigger checkout_error, and scroll to notices.
-            $('.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message').remove();
-            $(className).prepend(`<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"> ${error_div} </div>`);
-            $(className).removeClass('processing').unblock();
-            $(className).find('.input-text, select, input:checkbox').trigger('validate').blur();
-            $(document.body).trigger('checkout_error', [alert_message]);
-            $('html, body').animate({
-                scrollTop: ($(className).offset().top - 100)
-            }, 1000);
-        },
-
-        cleanupForm: function (formElement) {
-            const $inputs = formElement.find('input, select, textarea');
-            // remove inputs with empty values
-            const $inputsWithValue = $inputs.filter(function() {
-                return $(this).val() !== "";
-            });
-            const serializedData = $inputsWithValue.serialize();
-
-            return serializedData;
-        },
-
-        /**
-         * Places the Ledyer order
-         * @param {string} should_validate
-         */
-        placeLedyerOrder: function (should_validate = false) {
-            lco_wc.blocked = true;
-            lco_wc.getLedyerOrder().done(function (response) {
-                if (response.success) {
-                    $('.woocommerce-checkout-review-order-table').block({
-                        message: null,
-                        overlayCSS: {
-                            background: '#fff',
-                            opacity: 0.6
-                        }
-                    });
-
-                    sessionStorage.removeItem('ledyerWooRedirectUrl');
-
-                    $.ajax({
-                        type: 'POST',
-                        url: lco_params.submit_order,
-                        data: lco_wc.cleanupForm($('form.checkout')),
-                        dataType: 'json',
-                        success: function (data) {
-                            // data is an object with the following properties:
-                            // { result: "success" | "failure"; refresh: "boolean", reload: boolean, messages: string; }
-                            try {
-                                if ('success' === data.result) {
-                                    lco_wc.logToFile('Successfully created order in WooCommerce.');
-                                    const url = new URL(data.redirect);
-                                    sessionStorage.setItem('ledyerWooRedirectUrl', url);
-
-                                    if (should_validate) {
-                                        window.ledyer.api.clientValidation({
-                                            shouldProceed: true
-                                        })
-                                        // Ledyer will respond with a new event when order is complete
-                                        // So don't redirect just yet,
-                                        // eventually redirection will happen in ledyerCheckoutOrderComplete
-                                        return;
-                                    }
-                                    window.location.href = url.toString();
-                                } else {
-                                    throw 'Result failed';
-                                }
-                            } catch (err) {
-                                if (data.messages) {
-                                    lco_wc.logToFile('Checkout error | ' + data.messages);
-                                    lco_wc.failOrder("Vänligen kontrollera att alla uppgifter är korrekt ifyllda.", data.messages);
-                                } else {
-                                    lco_wc.logToFile('Checkout error | No message' + err);
-                                    lco_wc.failOrder();
-                                }
-                            }
-                        },
-                        error: function (data) {
-                            try {
-                                lco_wc.logToFile('AJAX error | ' + JSON.stringify(data));
-                            } catch (e) {
-                                lco_wc.logToFile('AJAX error | Failed to parse error message.');
-                            }
-                            lco_wc.failOrder();
-                        }
-                    });
-                } else {
-                    lco_wc.logToFile('Failed to get the order from Ledyer.');
-                    lco_wc.failOrder();
-                }
-            });
-        },
-
-        /**
-         * Initiates the script.
-         */
-        init: function () {
-            $(document).ready(lco_wc.documentReady);
-
-            if (0 < $('form.checkout #terms').length) {
-                $('form.checkout #terms').prop('checked', true);
-            }
-
-            lco_wc.bodyEl.on('update_checkout', lco_wc.lcoSuspend);
-            lco_wc.bodyEl.on('updated_checkout', lco_wc.lcoResume);
-            lco_wc.bodyEl.on('change', 'input.qty', lco_wc.updateCart);
-            lco_wc.bodyEl.on('change', 'input[name="payment_method"]', lco_wc.maybeChangeToLco);
-            lco_wc.bodyEl.on('click', lco_wc.selectAnotherSelector, lco_wc.changeFromLco);
-
-            $(document).on('ledyerCheckoutOrderComplete', function (event) {
-                lco_wc.logToFile('ledyerCheckoutOrderComplete from Ledyer triggered');
-                if (!lco_params.pay_for_order) {
-                    const redirectUrl = sessionStorage.getItem( 'ledyerWooRedirectUrl' );
-                    if (redirectUrl) {
-                        // This means that placeLedyerOrder was called successfully already
-                        // (Due to an earlier call caused by client validation)
-                        window.location.href = redirectUrl;
-                    }
-                }
-            });
-
-            $(document).on('ledyerCheckoutOrderPending', function (event) {
-                lco_wc.logToFile('ledyerCheckoutOrderPending from Ledyer triggered');
-                if (!lco_params.pay_for_order) {
-                    lco_wc.placeLedyerOrder();
-                }
-            });
-
-            $(document).on('ledyerCheckoutWaitingForClientValidation', function (event) {
-                lco_wc.logToFile('ledyerCheckoutWaitingForClientValidation from Ledyer triggered');
-
-                if (lco_params.pay_for_order) {
+                  if (should_validate) {
                     window.ledyer.api.clientValidation({
-                        shouldProceed: true
-                    })
+                      shouldProceed: true,
+                    });
+                    // Ledyer will respond with a new event when order is complete
+                    // So don't redirect just yet,
+                    // eventually redirection will happen in ledyerCheckoutOrderComplete
+                    return;
+                  }
+                  window.location.href = url.toString();
                 } else {
-                    lco_wc.placeLedyerOrder(true);
+                  throw "Result failed";
                 }
-            });
-        },
-    }
+              } catch (err) {
+                if (data.messages) {
+                  lco_wc.logToFile("Checkout error | " + data.messages);
+                  lco_wc.failOrder(
+                    "Vänligen kontrollera att alla uppgifter är korrekt ifyllda.",
+                    data.messages
+                  );
+                } else {
+                  lco_wc.logToFile("Checkout error | No message" + err);
+                  lco_wc.failOrder();
+                }
+              }
+            },
+            error: function (data) {
+              try {
+                lco_wc.logToFile("AJAX error | " + JSON.stringify(data));
+              } catch (e) {
+                lco_wc.logToFile("AJAX error | Failed to parse error message.");
+              }
+              lco_wc.failOrder();
+            },
+          });
+        } else {
+          lco_wc.logToFile("Failed to get the order from Ledyer.");
+          lco_wc.failOrder();
+        }
+      });
+    },
 
-    lco_wc.init();
+    /**
+     * Initiates the script.
+     */
+    init: function () {
+      $(document).ready(lco_wc.documentReady);
+
+      if (0 < $("form.checkout #terms").length) {
+        $("form.checkout #terms").prop("checked", true);
+      }
+
+      lco_wc.bodyEl.on("update_checkout", lco_wc.lcoSuspend);
+      lco_wc.bodyEl.on("updated_checkout", lco_wc.lcoResume);
+      lco_wc.bodyEl.on("change", "input.qty", lco_wc.updateCart);
+      lco_wc.bodyEl.on(
+        "change",
+        'input[name="payment_method"]',
+        lco_wc.maybeChangeToLco
+      );
+      lco_wc.bodyEl.on(
+        "click",
+        lco_wc.selectAnotherSelector,
+        lco_wc.changeFromLco
+      );
+
+      $(document).on("ledyerCheckoutOrderComplete", function (event) {
+        lco_wc.logToFile("ledyerCheckoutOrderComplete from Ledyer triggered");
+        if (!lco_params.pay_for_order) {
+          const redirectUrl = sessionStorage.getItem("ledyerWooRedirectUrl");
+          if (redirectUrl) {
+            // This means that placeLedyerOrder was called successfully already
+            // (Due to an earlier call caused by client validation)
+            window.location.href = redirectUrl;
+          }
+        }
+      });
+
+      $(document).on("ledyerCheckoutOrderPending", function (event) {
+        lco_wc.logToFile("ledyerCheckoutOrderPending from Ledyer triggered");
+        if (!lco_params.pay_for_order) {
+          lco_wc.placeLedyerOrder();
+        }
+      });
+
+      $(document).on(
+        "ledyerCheckoutWaitingForClientValidation",
+        function (event) {
+          lco_wc.logToFile(
+            "ledyerCheckoutWaitingForClientValidation from Ledyer triggered"
+          );
+
+          if (lco_params.pay_for_order) {
+            window.ledyer.api.clientValidation({
+              shouldProceed: true,
+            });
+          } else {
+            lco_wc.placeLedyerOrder(true);
+          }
+        }
+      );
+    },
+  };
+
+  lco_wc.init();
 });

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -51,7 +51,7 @@ class Ledyer_Checkout_For_WooCommerce {
 	 */
 	public $checkout;
 
-	const VERSION = '1.7.5';
+	const VERSION = '1.7.7';
 	const SLUG = 'ledyer-checkout-for-woocommerce';
 	const SETTINGS = 'ledyer_checkout_for_woocommerce_settings';
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,6 @@ Tested up to: 6.3
 Requires PHP: 7.0
 WC requires at least: 4.0.0
 WC tested up to: 8.2.0
-Stable tag: 1.7.5
+Stable tag: 1.7.7
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
For some reason we get two order notes fields, introduced when adding the missing setup for handling `extra fields` with `lco-extra-checkout-fields`.

Our setup is the same as Klarna, but for some reason the woocommerce field order notes is duplicated.

Verified that it still works, order notes is applied and shows in the order in woocommerce.