### PR TITLE
Allow Ledyer metabox to appear on WooCommerce Order screen

### DIFF
--- a/classes/admin/class-ledyer-meta-box.php
+++ b/classes/admin/class-ledyer-meta-box.php
@@ -29,17 +29,25 @@ class Meta_Box {
 	/**
 	 * Adds meta box to the side of a LCO order.
 	 *
-	 * @param string $post_type The WordPress post type.
+	 * @param string $screen_id The WordPress admin screen ID.
 	 * @return void
 	 */
-	public function add_meta_boxes( $post_type ) {
-		if ( 'shop_order' === $post_type ) {
+	public function add_meta_boxes( $screen_id ) {
+        $order_id = null;
+		if ( 'shop_order' === $screen_id ) {
 			$order_id = get_the_ID();
-			$order    = wc_get_order( $order_id );
-			if ( in_array( $order->get_payment_method(), array( 'lco', 'ledyer_payments' ), true ) ) {
-				add_meta_box( 'lco_meta_box', __( 'Ledyer Order Info', 'ledyer-checkout-for-woocommerce' ), array( $this, 'meta_box_content' ), 'shop_order', 'side', 'core' );
-			}
-		}
+		} elseif ( 'woocommerce_page_wc-orders' === $screen_id ) {
+            $order_id = $_GET['id'] ?? null;
+        }
+
+        if (null === $order_id) {
+            return;
+        }
+
+        $order = wc_get_order( $order_id );
+        if ( in_array( $order->get_payment_method(), array( 'lco', 'ledyer_payments' ), true ) ) {
+            add_meta_box( 'lco_meta_box', __( 'Ledyer Order Info', 'ledyer-checkout-for-woocommerce' ), array( $this, 'meta_box_content' ), $screen_id, 'side', 'core' );
+        }
 	}
 
 	/**


### PR DESCRIPTION
This PR is intended to fix the issue #120 allowing the metabox to show on WooCommerce Order screen, which was likely moved at some point and received a new screen ID.