### PR TITLE
Add notification URL to redirect order data

### DIFF
--- a/classes/requests/helpers/class-ledyer-woocommerce-bridge.php
+++ b/classes/requests/helpers/class-ledyer-woocommerce-bridge.php
@@ -87,6 +87,7 @@ class Woocommerce_Bridge {
 					'showShippingAddressContact' => 'yes' === ledyer()->get_setting( 'show_shipping_address_contact' ),
 				),
 				'urls'     => array(
+					'notification' => apply_filters( 'lco_notification_url', home_url( Callback::API_ENDPOINT ) ),
 					'terms'        => $merchant_urls['terms'],
 					'privacy'      => $merchant_urls['privacy'],
 					'confirmation' => $merchant_urls['confirmation'],


### PR DESCRIPTION
Add notification URL to redirect order data, to resolve issue with events not registering correctly for redirect orders.