### PR TITLE
Prevent sharing transaction ID

### DIFF
--- a/classes/class-ledyer-lco-gateway.php
+++ b/classes/class-ledyer-lco-gateway.php
@@ -318,8 +318,6 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 				$order->update_meta_data( '_wc_ledyer_session_id', $ledyer_order['id'] );
 
-				$order->set_transaction_id( $ledyer_order['orderId'] );
-
 				$order->update_meta_data( '_ledyer_company_id', $ledyer_order['customer']['companyId'] );
 
 				$order->update_meta_data( '_ledyer_company_name', $company_name );
@@ -355,7 +353,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				do_action( 'lco_wc_process_payment', $order_id, $ledyer_order );
 
 				// Check that the transaction id got set correctly.
-				if ( $order->get_transaction_id() === $ledyer_order_id ) {
+				if ( $order->get_meta( '_wc_ledyer_order_id' ) === $ledyer_order_id ) {
 					return true;
 				}
 			}

--- a/includes/lco-functions.php
+++ b/includes/lco-functions.php
@@ -30,9 +30,8 @@ function lco_create_or_update_order() {
 		$ledyer_session_id = WC()->session->get( 'lco_wc_session_id' );
 		$data              = \Ledyer\Requests\Helpers\Woocommerce_Bridge::get_updated_cart_data();
 		$ledyer_order      = ledyer()->api->update_order_session( $ledyer_order_id, $data );
-		$duplicate_exists  = ledyer_order_already_exist( $ledyer_order_id );
 
-		if ( $duplicate_exists || ! $ledyer_order || ( is_object( $ledyer_order ) && is_wp_error( $ledyer_order ) ) || $ledyer_order['orderId'] !== $ledyer_order_id || $ledyer_order['sessionId'] !== $ledyer_session_id ) {
+		if ( ! $ledyer_order || ( is_object( $ledyer_order ) && is_wp_error( $ledyer_order ) ) || $ledyer_order['orderId'] !== $ledyer_order_id || $ledyer_order['sessionId'] !== $ledyer_session_id ) {
 			// If update order failed try to create new order.
 			$data         = \Ledyer\Requests\Helpers\Woocommerce_Bridge::get_cart_data();
 			$ledyer_order = ledyer()->api->create_order_session( $data );
@@ -200,41 +199,4 @@ function wc_ledyer_cart_redirect() {
 
 	wp_safe_redirect( $url );
 	exit;
-}
-
-/**
- * Checks if an order with the current Ledyer order ID already exists.
- *
- * @param string $ledyer_order_id The Ledyer order ID to check for.
- * @return bool
- */
-function ledyer_order_already_exist( $ledyer_order_id ) {
-
-	if ( ! $ledyer_order_id ) {
-		return false;
-	}
-	// Get by WC order key.
-	$orders = wc_get_orders(
-		array(
-			'meta_key'     => '_wc_ledyer_order_id',
-			'meta_value'   => $ledyer_order_id,
-			'meta_compare' => '=',
-			'limit'        => 2,
-		)
-	);
-
-	if ( 2 !== count( $orders ) ) {
-		return false;
-	}
-
-	// Make sure that both orders have the same Ledyer order ID, just in case.
-	foreach ( $orders as $order ) {
-		$order_ledyer_order_id = $order->get_meta( '_wc_ledyer_order_id' );
-
-		if ( $order_ledyer_order_id !== $ledyer_order_id ) {
-			return false;
-		}
-	}
-
-	return true;
 }

--- a/includes/lco-functions.php
+++ b/includes/lco-functions.php
@@ -30,8 +30,9 @@ function lco_create_or_update_order() {
 		$ledyer_session_id = WC()->session->get( 'lco_wc_session_id' );
 		$data              = \Ledyer\Requests\Helpers\Woocommerce_Bridge::get_updated_cart_data();
 		$ledyer_order      = ledyer()->api->update_order_session( $ledyer_order_id, $data );
+		$duplicate_exists  = ledyer_order_already_exist( $ledyer_order_id );
 
-		if ( ! $ledyer_order || ( is_object( $ledyer_order ) && is_wp_error( $ledyer_order ) ) || $ledyer_order['orderId'] !== $ledyer_order_id || $ledyer_order['sessionId'] !== $ledyer_session_id ) {
+		if ( $duplicate_exists || ! $ledyer_order || ( is_object( $ledyer_order ) && is_wp_error( $ledyer_order ) ) || $ledyer_order['orderId'] !== $ledyer_order_id || $ledyer_order['sessionId'] !== $ledyer_session_id ) {
 			// If update order failed try to create new order.
 			$data         = \Ledyer\Requests\Helpers\Woocommerce_Bridge::get_cart_data();
 			$ledyer_order = ledyer()->api->create_order_session( $data );
@@ -199,4 +200,41 @@ function wc_ledyer_cart_redirect() {
 
 	wp_safe_redirect( $url );
 	exit;
+}
+
+/**
+ * Checks if an order with the current Ledyer order ID already exists.
+ *
+ * @param string $ledyer_order_id The Ledyer order ID to check for.
+ * @return bool
+ */
+function ledyer_order_already_exist( $ledyer_order_id ) {
+
+	if ( ! $ledyer_order_id ) {
+		return false;
+	}
+	// Get by WC order key.
+	$orders = wc_get_orders(
+		array(
+			'meta_key'     => '_wc_ledyer_order_id',
+			'meta_value'   => $ledyer_order_id,
+			'meta_compare' => '=',
+			'limit'        => 2,
+		)
+	);
+
+	if ( 2 !== count( $orders ) ) {
+		return false;
+	}
+
+	// Make sure that both orders have the same Ledyer order ID, just in case.
+	foreach ( $orders as $order ) {
+		$order_ledyer_order_id = $order->get_meta( '_wc_ledyer_order_id' );
+
+		if ( $order_ledyer_order_id !== $ledyer_order_id ) {
+			return false;
+		}
+	}
+
+	return true;
 }


### PR DESCRIPTION
Prevent multiple orders from sharing the same transaction ID, by not setting the transaction ID too early. Does seem to work well for me!

Can be tested by starting a payment process in the Ledyer iframe in checkout, cancelling it, adding a coupon code to the cart, and finally continuing with the payment again.

Previously, two orders sharing the same transaction ID was created. Now, only the paid order should have a transaction ID set and is therefore not linked to the first pending order.