### PR TITLE
Save shipping_phone and hide field by default

### DIFF
--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -392,27 +392,6 @@ jQuery( function ( $ ) {
 					  )
 					: '';
 
-				// extra shipping fields (email, phone, name).
-				if (
-					lco_wc.shippingEmailExists === true &&
-					$( '#shipping_email' )
-				) {
-					$( '#shipping_email' ).val(
-						'shipping_email' in data.shipping_address
-							? data.shipping_address.shipping_email
-							: ''
-					);
-				}
-				if (
-					lco_wc.shippingPhoneExists === true &&
-					$( '#shipping_phone' )
-				) {
-					$( '#shipping_phone' ).val(
-						'shipping_phone' in data.shipping_address
-							? data.shipping_address.shipping_phone
-							: ''
-					);
-				}
 				if (
 					lco_wc.shippingFirstNameExists === true &&
 					$( '#shipping_first_name' )
@@ -433,6 +412,25 @@ jQuery( function ( $ ) {
 							: ''
 					);
 				}
+			}
+
+			const shippingAddress = data.shipping_address || {};
+			const billingAddress = data.billing_address || {};
+			const $shippingPhone = $( '#shipping_phone' );
+			if ( $shippingPhone.length ) {
+				$shippingPhone.val(
+					shippingAddress.shipping_phone ||
+					billingAddress.billing_phone ||
+					''
+				);
+			}
+			const $shippingEmail = $( '#shipping_email' );
+			if ( $shippingEmail.length ) {
+				$shippingEmail.val(
+					shippingAddress.shipping_email ||
+					billingAddress.billing_email ||
+					''
+				);
 			}
 		},
 

--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -26,8 +26,6 @@ jQuery( function ( $ ) {
 
 		// True or false if we need to update the Ledyer order. Set to false on initial page load.
 		ledyerUpdateNeeded: false,
-		shippingEmailExists: false,
-		shippingPhoneExists: false,
 		shippingFirstNameExists: false,
 		shippingLastNameExists: false,
 
@@ -188,12 +186,6 @@ jQuery( function ( $ ) {
 							);
 						}
 					} else if ( 0 < $( 'p#' + name + '_field' ).length ) {
-						if ( name === 'shipping_phone' ) {
-							lco_wc.shippingPhoneExists = true;
-						}
-						if ( name === 'shipping_email' ) {
-							lco_wc.shippingEmailExists = true;
-						}
 						if ( name === 'shipping_first_name' ) {
 							lco_wc.shippingFirstNameExists = true;
 						}

--- a/classes/class-ledyer-ajax.php
+++ b/classes/class-ledyer-ajax.php
@@ -239,11 +239,11 @@ class AJAX extends \WC_AJAX {
 						break;
 					case 'shipping_phone':
 						$shipping_phone                     = $ledyer_order['customer']['shippingAddress']['contact']['phone'] ?? '';
-						$fields['shipping_address'][ $key ] = $shipping_phone ?: ( $ledyer_order['customer']['phone'] ?? '' );
+						$fields['shipping_address'][ $key ] = ! empty( $shipping_phone ) ? $shipping_phone : ( $ledyer_order['customer']['phone'] ?? '' );
 						break;
 					case 'shipping_email':
 						$shipping_email                     = $ledyer_order['customer']['shippingAddress']['contact']['email'] ?? '';
-						$fields['shipping_address'][ $key ] = $shipping_email ?: ( $ledyer_order['customer']['email'] ?? '' );
+						$fields['shipping_address'][ $key ] = ! empty( $shipping_email ) ? $shipping_email : ( $ledyer_order['customer']['email'] ?? '' );
 						break;
 					default:
 						unset( $fields[ $key ] );

--- a/classes/class-ledyer-ajax.php
+++ b/classes/class-ledyer-ajax.php
@@ -238,10 +238,12 @@ class AJAX extends \WC_AJAX {
 						$fields['billing_address'][ $key ] = $ledyer_order['customer']['email'];
 						break;
 					case 'shipping_phone':
-						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['phone'] : '';
+						$shipping_phone                      = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['phone'] : '';
+						$fields['shipping_address'][ $key ] = $shipping_phone ?: $ledyer_order['customer']['phone'];
 						break;
 					case 'shipping_email':
-						$fields['shipping_address'][ $key ] = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['email'] : '';
+						$shipping_email                      = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['email'] : '';
+						$fields['shipping_address'][ $key ] = $shipping_email ?: $ledyer_order['customer']['email'];
 						break;
 					default:
 						unset( $fields[ $key ] );

--- a/classes/class-ledyer-ajax.php
+++ b/classes/class-ledyer-ajax.php
@@ -238,12 +238,12 @@ class AJAX extends \WC_AJAX {
 						$fields['billing_address'][ $key ] = $ledyer_order['customer']['email'];
 						break;
 					case 'shipping_phone':
-						$shipping_phone                      = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['phone'] : '';
-						$fields['shipping_address'][ $key ] = $shipping_phone ?: $ledyer_order['customer']['phone'];
+						$shipping_phone                     = $ledyer_order['customer']['shippingAddress']['contact']['phone'] ?? '';
+						$fields['shipping_address'][ $key ] = $shipping_phone ?: ( $ledyer_order['customer']['phone'] ?? '' );
 						break;
 					case 'shipping_email':
-						$shipping_email                      = isset( $ledyer_order['customer']['shippingAddress']['contact'] ) ? $ledyer_order['customer']['shippingAddress']['contact']['email'] : '';
-						$fields['shipping_address'][ $key ] = $shipping_email ?: $ledyer_order['customer']['email'];
+						$shipping_email                     = $ledyer_order['customer']['shippingAddress']['contact']['email'] ?? '';
+						$fields['shipping_address'][ $key ] = $shipping_email ?: ( $ledyer_order['customer']['email'] ?? '' );
 						break;
 					default:
 						unset( $fields[ $key ] );

--- a/classes/class-ledyer-lco-gateway.php
+++ b/classes/class-ledyer-lco-gateway.php
@@ -206,6 +206,8 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 					'shipping_postcode',
 					'shipping_city',
 					'shipping_state',
+					'shipping_phone',
+					'shipping_email',
 					'shipping_country',
 					'shipping_company',
 					'terms',


### PR DESCRIPTION
- Fix - Resolved a checkout validation error that could occur after upgrading to WooCommerce 10.8.0, where an empty shipping phone number caused the order to fail. The shipping phone field is now correctly populated with the value from Ledyer, or the billing phone number if no shipping phone is provided.

https://app.clickup.com/2423261/dashboards/29yex-1025